### PR TITLE
add text publisher channel

### DIFF
--- a/pytrickle/client.py
+++ b/pytrickle/client.py
@@ -25,6 +25,7 @@ class TrickleClient:
         publish_url: str,
         control_url: Optional[str] = None,
         events_url: Optional[str] = None,
+        text_url: Optional[str] = None,
         width: int = 512,
         height: int = 512,
         frame_processor: Optional[Callable[[VideoFrame], VideoOutput]] = None,
@@ -35,6 +36,7 @@ class TrickleClient:
             publish_url=publish_url, 
             control_url=control_url,
             events_url=events_url,
+            text_url=text_url,
             width=width,
             height=height,
             error_callback=self._on_protocol_error
@@ -222,6 +224,10 @@ class TrickleClient:
                     self.error_callback(error_type, exception)
             except Exception as e:
                 logger.error(f"Error in error callback: {e}")
+
+    async def publish_text(self, text_data: str):
+        """Publish text data via the text publisher."""
+        await self.protocol.publish_text(text_data)
 
 class SimpleTrickleClient:
     """Simplified trickle client for basic use cases."""

--- a/pytrickle/client.py
+++ b/pytrickle/client.py
@@ -25,7 +25,7 @@ class TrickleClient:
         publish_url: str,
         control_url: Optional[str] = None,
         events_url: Optional[str] = None,
-        text_url: Optional[str] = None,
+        data_url: Optional[str] = None,
         width: int = 512,
         height: int = 512,
         frame_processor: Optional[Callable[[VideoFrame], VideoOutput]] = None,
@@ -36,7 +36,7 @@ class TrickleClient:
             publish_url=publish_url, 
             control_url=control_url,
             events_url=events_url,
-            text_url=text_url,
+            data_url=data_url,
             width=width,
             height=height,
             error_callback=self._on_protocol_error
@@ -225,9 +225,9 @@ class TrickleClient:
             except Exception as e:
                 logger.error(f"Error in error callback: {e}")
 
-    async def publish_text(self, text_data: str):
-        """Publish text data via the text publisher."""
-        await self.protocol.publish_text(text_data)
+    async def publish_data(self, data: str):
+        """Publish data via the data publisher."""
+        await self.protocol.publish_data(data)
 
 class SimpleTrickleClient:
     """Simplified trickle client for basic use cases."""

--- a/pytrickle/protocol.py
+++ b/pytrickle/protocol.py
@@ -46,7 +46,7 @@ class TrickleProtocol:
         publish_url: str, 
         control_url: Optional[str] = None, 
         events_url: Optional[str] = None, 
-        text_url: Optional[str] = None,
+        data_url: Optional[str] = None,
         width: Optional[int] = DEFAULT_WIDTH, 
         height: Optional[int] = DEFAULT_HEIGHT,
         error_callback: Optional[ErrorCallback] = None
@@ -55,7 +55,7 @@ class TrickleProtocol:
         self.publish_url = publish_url
         self.control_url = control_url
         self.events_url = events_url
-        self.text_url = text_url
+        self.data_url = data_url
         self.width = width
         self.height = height
         self.error_callback = error_callback
@@ -67,8 +67,8 @@ class TrickleProtocol:
         # Control and events components
         self.control_subscriber: Optional[TrickleSubscriber] = None
         self.events_publisher: Optional[TricklePublisher] = None
-        self.text_publisher: Optional[TricklePublisher] = None
-        
+        self.data_publisher: Optional[TricklePublisher] = None
+
         # Background tasks
         self.subscribe_task: Optional[asyncio.Task] = None
         self.publish_task: Optional[asyncio.Task] = None
@@ -135,10 +135,10 @@ class TrickleProtocol:
             self.events_publisher = TricklePublisher(self.events_url, "application/json", error_callback=self._on_component_error)
             await self.events_publisher.start()
             
-        # Initialize text publisher if URL provided
-        if self.text_url and self.text_url.strip():
-            self.text_publisher = TricklePublisher(self.text_url, "text/plain", error_callback=self._on_component_error)
-            await self.text_publisher.start()
+        # Initialize data publisher if URL provided
+        if self.data_url and self.data_url.strip():
+            self.data_publisher = TricklePublisher(self.data_url, "application/octet-stream", error_callback=self._on_component_error)
+            await self.data_publisher.start()
 
     async def stop(self):
         """Stop the trickle protocol."""
@@ -160,9 +160,9 @@ class TrickleProtocol:
             await self.events_publisher.close()
             self.events_publisher = None
 
-        if self.text_publisher:
-            await self.text_publisher.close()
-            self.text_publisher = None
+        if self.data_publisher:
+            await self.data_publisher.close()
+            self.data_publisher = None
 
         # Wait for tasks to complete with timeout
         tasks = [self.subscribe_task, self.publish_task]
@@ -248,12 +248,12 @@ class TrickleProtocol:
                 logger.error(f"Error in control loop", exc_info=True)
                 continue
 
-    async def publish_text(self, text_data: str):
-        """Publish text data via the text publisher."""
-        if not self.text_publisher:
+    async def publish_data(self, data: str):
+        """Publish data via the data publisher."""
+        if not self.data_publisher:
             return
         try:
-            async with await self.text_publisher.next() as segment:
-                await segment.write(text_data.encode('utf-8'))
+            async with await self.data_publisher.next() as segment:
+                await segment.write(data.encode('utf-8'))
         except Exception as e:
-            logger.error(f"Error publishing text data: {e}") 
+            logger.error(f"Error publishing data: {e}")


### PR DESCRIPTION
This pull request introduces support for a new `data_url` parameter and functionality to publish data via a `data_publisher` in the `pytrickle` library. Key changes include updates to the initialization process, the addition of a `publish_data` method, and modifications to the `start` and `stop` lifecycle methods to handle the new publisher.

### Enhancements to `pytrickle.client`:

* Added a `data_url` parameter to the `__init__` method of `TrickleClient`, ensuring it is passed to the protocol layer. [[1]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabR28) [[2]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabR39)
* Introduced an `async def publish_data` method in `TrickleClient` to publish data using the protocol's `publish_data` method.

### Enhancements to `pytrickle.protocol`:

* Added a `data_url` parameter and a `data_publisher` attribute to the `__init__` method of `TrickleProtocol`. [[1]](diffhunk://#diff-f1e4535db260fa1af520b44c4057fe2b0626101b233037ca0a532471659d7a9dR49) [[2]](diffhunk://#diff-f1e4535db260fa1af520b44c4057fe2b0626101b233037ca0a532471659d7a9dR58) [[3]](diffhunk://#diff-f1e4535db260fa1af520b44c4057fe2b0626101b233037ca0a532471659d7a9dR70)
* Modified the `start` method to initialize the `data_publisher` if a `data_url` is provided.
* Updated the `stop` method to cleanly close the `data_publisher` if it was initialized.
* Added an `async def publish_data` method to `TrickleProtocol` to handle data publishing via the `data_publisher` with error handling.