### PR TITLE
pass audio frames to frame processor

### DIFF
--- a/pytrickle/protocol.py
+++ b/pytrickle/protocol.py
@@ -192,11 +192,7 @@ class TrickleProtocol:
             if frame is None:  # Sentinel value
                 break
             
-            # Handle audio frames (pass through for now)
-            if isinstance(frame, AudioFrame):
-                self.publish_queue.put(AudioOutput([frame], ""))
-                continue
-            
+            # Send all frames (video and audio) to frame processor
             yield frame
 
     async def egress_loop(self, output_frames: AsyncGenerator[OutputFrame, None]):


### PR DESCRIPTION
This pull request enhances the `pytrickle` client to support processing both audio and video frames, in addition to improving the frame handling logic. The key changes include extending the frame processor to handle audio frames, updating default behaviors, and modifying the ingress and egress loops for better audio frame support.

### Support for audio frame processing:
* Updated imports in `pytrickle/client.py` to include `AudioFrame` and `AudioOutput` for handling audio data. (`[pytrickle/client.pyL11-R14](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabL11-R14)`)
* Modified the `frame_processor` parameter and `_default_frame_processor` method to accept and process both `VideoFrame` and `AudioFrame`, returning the appropriate output type. (`[[1]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabL31-R31)`, `[[2]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabL53-R58)`)

### Ingress loop enhancements:
* Added logic to process audio frames in the `async def _ingress_loop(self)` method, including sending processed audio frames to egress and logging relevant details. (`[pytrickle/client.pyR123-R135](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabR123-R135)`)

### Stream processing updates:
* Updated the `process_stream` method to support a frame processor that handles both audio and video frames. (`[pytrickle/client.pyL242-R256](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabL242-R256)`)

### Egress loop simplification:
* Removed the special handling of audio frames in the `dequeue_frame` method, ensuring all frames (audio and video) are sent to the frame processor uniformly. (`[pytrickle/protocol.pyL195-R195](diffhunk://#diff-f1e4535db260fa1af520b44c4057fe2b0626101b233037ca0a532471659d7a9dL195-R195)`)