### PR TITLE
feat: queue mode with improved server/client state

### DIFF
--- a/examples/async_output_drain_example.py
+++ b/examples/async_output_drain_example.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""
+Minimal Async FrameProcessor Demo (queue_mode + output drain)
+
+This example shows the new pattern where a custom `FrameProcessor` runs in
+queue_mode so the Trickle client drains processed outputs via its output drain
+task. Audio is passed through unchanged (audio_concurrency=0), while video is
+processed asynchronously with a subtle Accent Green color tint.
+
+HTTP API (served by StreamServer):
+- POST /api/stream/start
+- POST /api/stream/params
+- GET  /api/stream/status
+
+Usage:
+    python async_output_drain_example.py
+
+Then start a stream with something like:
+    curl -X POST http://localhost:8000/api/stream/start \
+      -H 'Content-Type: application/json' \
+      -d '{
+            "subscribe_url": "http://127.0.0.1:3389/sample",
+            "publish_url":   "http://127.0.0.1:3389/output",
+            "gateway_request_id": "demo",
+            "params": {"intensity": 0.5}
+          }'
+"""
+
+import asyncio
+import logging
+from typing import Optional, Dict, Any, List
+
+import torch
+
+from pytrickle import FrameProcessor, StreamServer
+from pytrickle.frames import VideoFrame, AudioFrame
+
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class MinimalAsyncProcessor(FrameProcessor):
+    """Tiny async video processor with audio passthrough.
+
+    - Runs with queue_mode enabled so outputs are drained by the client
+    - Video: applies a subtle Accent Green (#18794E) color tint with adjustable intensity
+    - Audio: passthrough (audio_concurrency=0)
+    """
+
+    def __init__(
+        self,
+        intensity: float = 0.5,
+        **kwargs
+    ):
+        # Log errors via a simple callback
+        def log_error(error_type: str, exception: Optional[Exception] = None):
+            logger.warning(f"Processing error: {error_type} - {exception}")
+
+        self.intensity = float(intensity)
+        self.ready = False
+
+        super().__init__(
+            error_callback=log_error,
+            queue_mode=True,
+            video_queue_size=8,
+            audio_queue_size=32,
+            video_concurrency=1,
+            audio_concurrency=0,
+            **kwargs
+        )
+
+    def initialize(self, **kwargs):
+        # Allow intensity override from kwargs
+        if "intensity" in kwargs:
+            try:
+                self.intensity = float(kwargs["intensity"])
+            except Exception:
+                pass
+        # Clamp between 0 and 1
+        self.intensity = max(0.0, min(1.0, self.intensity))
+        self.ready = True
+        logger.info(f"✅ MinimalAsyncProcessor ready (intensity={self.intensity:.3f})")
+
+    async def process_video_async(self, frame: VideoFrame) -> Optional[VideoFrame]:
+        if not self.ready:
+            return None
+        try:
+            tensor = frame.tensor
+            if tensor is None:
+                return None
+            if tensor.dtype != torch.float32:
+                tensor = tensor.float()
+            # Ensure 4D (N H W C)
+            if hasattr(tensor, "ndim") and tensor.ndim == 3:
+                tensor = tensor.unsqueeze(0)
+
+            # Apply Accent Green tint (#18794E -> rgb approx [0.094, 0.475, 0.306])
+            if self.intensity > 0.0:
+                target = torch.tensor([0.094, 0.475, 0.306], device=tensor.device, dtype=tensor.dtype)
+                tinted = torch.clamp(tensor + (target - 0.5) * 0.4, 0.0, 1.0)
+                tensor = tensor * (1.0 - self.intensity) + tinted * self.intensity
+                tensor = torch.clamp(tensor, 0.0, 1.0)
+
+            return frame.replace_tensor(tensor)
+        except Exception as e:
+            if self.error_callback:
+                try:
+                    self.error_callback("video_processing_error", e)
+                except Exception:
+                    pass
+            return None
+
+    async def process_audio_async(self, frame: AudioFrame) -> Optional[List[AudioFrame]]:
+        # Passthrough audio unchanged
+        return [frame]
+
+    def update_params(self, params: Dict[str, Any]):
+        if not params:
+            return
+        if "intensity" in params:
+            try:
+                new_i = float(params["intensity"])
+                new_i = max(0.0, min(1.0, new_i))
+                if new_i != self.intensity:
+                    old = self.intensity
+                    self.intensity = new_i
+                    logger.info(f"Intensity: {old:.3f} → {self.intensity:.3f}")
+            except Exception:
+                pass
+
+
+async def main():
+    server = None
+    try:
+        processor = MinimalAsyncProcessor(
+            intensity=0.5
+        )
+
+        server = StreamServer(
+            frame_processor=processor,
+            port=8000,
+            host="0.0.0.0",
+            capability_name="minimal-async-output-drain"
+        )
+
+        logger.info("🌐 Service ready at http://localhost:8000")
+        logger.info("API: /api/stream/start, /api/stream/params, /api/stream/status")
+        await server.run_forever()
+    except KeyboardInterrupt:
+        logger.info("🛑 Service stopped")
+    finally:
+        if server is not None:
+            await server.stop()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+
+

--- a/pytrickle/client.py
+++ b/pytrickle/client.py
@@ -77,6 +77,13 @@ class TrickleClient:
         self.request_id = request_id
         self.stop_event.clear()
         self.error_event.clear()
+        # Drain any stale frames (including sentinel) from previous stream
+        try:
+            while not self.output_queue.empty():
+                self.output_queue.get_nowait()
+                self.output_queue.task_done()
+        except Exception:
+            pass
         
         logger.info(f"Starting trickle client with request_id={request_id}")
         

--- a/pytrickle/client.py
+++ b/pytrickle/client.py
@@ -197,7 +197,6 @@ class TrickleClient:
                 # Process frames directly in ingress loop
                 try:
                     if isinstance(frame, VideoFrame):
-                        logger.debug(f"Processing video frame with frame processor: {frame.tensor.shape}")
                         if getattr(self.frame_processor, "queue_mode", False):
                             # Enqueue for background processing
                             await self.frame_processor.enqueue_video_frame(frame)
@@ -212,7 +211,6 @@ class TrickleClient:
                                 logger.warning(f"Frame processor returned None for video frame")
                             
                     elif isinstance(frame, AudioFrame):
-                        logger.debug(f"Processing audio frame with frame processor: {frame.samples.shape}")
                         if getattr(self.frame_processor, "queue_mode", False):
                             # Check if audio workers are disabled (passthrough mode)
                             audio_concurrency = self.frame_processor._audio_concurrency

--- a/pytrickle/frame_processor.py
+++ b/pytrickle/frame_processor.py
@@ -180,14 +180,6 @@ class FrameProcessor(ABC):
         """Optional hook to reset timing state (e.g., frame counters) between streams."""
         return
 
-    async def pause_inputs(self) -> None:
-        """Optional hook to pause accepting inputs (subclasses may implement)."""
-        return
-
-    async def resume_inputs(self) -> None:
-        """Optional hook to resume accepting inputs (subclasses may implement)."""
-        return
-
     async def enqueue_video_frame(self, frame: VideoFrame) -> None:
         if not self.queue_mode or self._video_in_q is None:
             raise RuntimeError("Queue mode is disabled on FrameProcessor")

--- a/pytrickle/frame_processor.py
+++ b/pytrickle/frame_processor.py
@@ -2,9 +2,15 @@
 Frame Processor - Async processing utilities for PyTrickle.
 This module provides base classes and utilities for async frame processing,
 making it easy to integrate AI models and async pipelines with PyTrickle.
+
+Enhancements:
+- Optional internal queue/buffer mode for decoupled ingress/egress
+- Built-in worker tasks that consume input queues and produce output queues
+  while calling the subclass processing methods
 """
 
 import logging
+import asyncio
 from abc import ABC, abstractmethod
 from typing import Optional, Any, Dict, List
 from .frames import VideoFrame, AudioFrame
@@ -43,16 +49,228 @@ class FrameProcessor(ABC):
     def __init__(
         self,
         error_callback: Optional[ErrorCallback] = None,
+        # Queue/Buffer mode (optional)
+        queue_mode: bool = False,
+        video_queue_size: int = 8,
+        audio_queue_size: int = 32,
+        video_concurrency: int = 1,
+        audio_concurrency: int = 1,
         **init_kwargs
     ):
         """Initialize the frame processor.
         
         Args:
             error_callback: Optional error callback for processing errors
+            queue_mode: Enable internal queued processing with worker tasks
+            video_queue_size: Max buffered video frames
+            audio_queue_size: Max buffered audio frames
+            video_concurrency: Number of concurrent video workers
+            audio_concurrency: Number of concurrent audio workers
             **init_kwargs: Additional kwargs passed to initialize() method
         """
         self.error_callback = error_callback
+        # Queue mode configuration
+        self.queue_mode = bool(queue_mode)
+        self._video_in_q: Optional[asyncio.Queue] = None
+        self._audio_in_q: Optional[asyncio.Queue] = None
+        self._video_out_q: Optional[asyncio.Queue] = None
+        self._audio_out_q: Optional[asyncio.Queue] = None
+        self._stop_event: Optional[asyncio.Event] = None
+        self._video_workers: List[asyncio.Task] = []
+        self._audio_workers: List[asyncio.Task] = []
+        self._video_queue_size = int(video_queue_size)
+        self._audio_queue_size = int(audio_queue_size)
+        self._video_concurrency = max(1, int(video_concurrency))
+        self._audio_concurrency = max(1, int(audio_concurrency))
+
         self.initialize(**init_kwargs)
+
+    # ========= Optional queued IO API =========
+    async def start_queue_workers(self) -> None:
+        """Start internal processing workers when queue_mode is enabled.
+
+        In queue mode, TrickleClient can enqueue frames via enqueue_* and
+        read processed frames via get_next_processed_* without blocking ingress.
+        """
+        if not self.queue_mode:
+            return
+        # Clear any stale items before starting to avoid cross-stream jitter
+        try:
+            for q in [self._video_in_q, self._audio_in_q, self._video_out_q, self._audio_out_q]:
+                if isinstance(q, asyncio.Queue):
+                    while not q.empty():
+                        q.get_nowait()
+                        q.task_done()
+        except Exception:
+            pass
+
+        # Always recreate a fresh stop event on (re)start so workers run after previous stop
+        self._stop_event = asyncio.Event()
+        # Initialize queues lazily
+        if self._video_in_q is None:
+            self._video_in_q = asyncio.Queue(maxsize=self._video_queue_size)
+        if self._audio_in_q is None:
+            self._audio_in_q = asyncio.Queue(maxsize=self._audio_queue_size)
+        if self._video_out_q is None:
+            self._video_out_q = asyncio.Queue(maxsize=self._video_queue_size)
+        if self._audio_out_q is None:
+            self._audio_out_q = asyncio.Queue(maxsize=self._audio_queue_size)
+        # Spawn workers
+        for _ in range(self._video_concurrency):
+            self._video_workers.append(asyncio.create_task(self._video_worker()))
+        for _ in range(self._audio_concurrency):
+            self._audio_workers.append(asyncio.create_task(self._audio_worker()))
+
+    async def stop_queue_workers(self) -> None:
+        """Stop internal processing workers and drain queues."""
+        if not self.queue_mode:
+            return
+        if self._stop_event:
+            self._stop_event.set()
+        # Cancel workers
+        for task in self._video_workers + self._audio_workers:
+            task.cancel()
+        for task in self._video_workers + self._audio_workers:
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+            except Exception as e:
+                logger.warning(f"Worker ended with error: {e}")
+        self._video_workers.clear()
+        self._audio_workers.clear()
+
+        # Best-effort drain
+        for q in [self._video_in_q, self._audio_in_q, self._video_out_q, self._audio_out_q]:
+            if isinstance(q, asyncio.Queue):
+                try:
+                    while not q.empty():
+                        q.get_nowait()
+                        q.task_done()
+                except Exception:
+                    pass
+
+    async def reset_state(self) -> None:
+        """Reset internal queued state (drain queues, clear stop flag).
+
+        Safe to call between streams to ensure clean start.
+        """
+        if not self.queue_mode:
+            return
+        # Do not cancel workers here; just clear queues and reset stop flag
+        try:
+            for q in [self._video_in_q, self._audio_in_q, self._video_out_q, self._audio_out_q]:
+                if isinstance(q, asyncio.Queue):
+                    while not q.empty():
+                        try:
+                            q.get_nowait()
+                            q.task_done()
+                        except asyncio.QueueEmpty:
+                            break
+                        except Exception:
+                            break
+        except Exception:
+            pass
+        # Reset stop event so workers run on next start
+        if self._stop_event is None or self._stop_event.is_set():
+            self._stop_event = asyncio.Event()
+
+    # ===== Optional lifecycle hooks; subclasses may override =====
+    async def reset_timing(self) -> None:
+        """Optional hook to reset timing state (e.g., frame counters) between streams."""
+        return
+
+    async def pause_inputs(self) -> None:
+        """Optional hook to pause accepting inputs (subclasses may implement)."""
+        return
+
+    async def resume_inputs(self) -> None:
+        """Optional hook to resume accepting inputs (subclasses may implement)."""
+        return
+
+    async def enqueue_video_frame(self, frame: VideoFrame) -> None:
+        if not self.queue_mode or self._video_in_q is None:
+            raise RuntimeError("Queue mode is disabled on FrameProcessor")
+        try:
+            await self._video_in_q.put(frame)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"Failed to enqueue video frame: {e}")
+
+    async def enqueue_audio_frame(self, frame: AudioFrame) -> None:
+        if not self.queue_mode or self._audio_in_q is None:
+            raise RuntimeError("Queue mode is disabled on FrameProcessor")
+        try:
+            await self._audio_in_q.put(frame)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"Failed to enqueue audio frame: {e}")
+
+    async def get_next_processed_video(self) -> Optional[VideoFrame]:
+        if not self.queue_mode or self._video_out_q is None:
+            raise RuntimeError("Queue mode is disabled on FrameProcessor")
+        try:
+            return await self._video_out_q.get()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"Failed to dequeue processed video: {e}")
+            return None
+
+    async def get_next_processed_audio(self) -> Optional[List[AudioFrame]]:
+        if not self.queue_mode or self._audio_out_q is None:
+            raise RuntimeError("Queue mode is disabled on FrameProcessor")
+        try:
+            return await self._audio_out_q.get()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error(f"Failed to dequeue processed audio: {e}")
+            return None
+
+    async def _video_worker(self) -> None:
+        assert self._video_in_q is not None and self._video_out_q is not None
+        while self._stop_event and not self._stop_event.is_set():
+            try:
+                frame = await self._video_in_q.get()
+                processed = await self.process_video_async(frame)
+                if processed is not None:
+                    await self._video_out_q.put(processed)
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"Video worker error: {e}")
+                if self.error_callback:
+                    try:
+                        if asyncio.iscoroutinefunction(self.error_callback):
+                            await self.error_callback("video_worker_error", e)
+                        else:
+                            self.error_callback("video_worker_error", e)
+                    except Exception:
+                        pass
+
+    async def _audio_worker(self) -> None:
+        assert self._audio_in_q is not None and self._audio_out_q is not None
+        while self._stop_event and not self._stop_event.is_set():
+            try:
+                frame = await self._audio_in_q.get()
+                processed_list = await self.process_audio_async(frame)
+                if processed_list:
+                    await self._audio_out_q.put(processed_list)
+            except asyncio.CancelledError:
+                break
+            except Exception as e:
+                logger.error(f"Audio worker error: {e}")
+                if self.error_callback:
+                    try:
+                        if asyncio.iscoroutinefunction(self.error_callback):
+                            await self.error_callback("audio_worker_error", e)
+                        else:
+                            self.error_callback("audio_worker_error", e)
+                    except Exception:
+                        pass
 
     # Abstract methods to implement in subclasses
     @abstractmethod

--- a/pytrickle/frame_processor.py
+++ b/pytrickle/frame_processor.py
@@ -54,7 +54,7 @@ class FrameProcessor(ABC):
         video_queue_size: int = 8,
         audio_queue_size: int = 32,
         video_concurrency: int = 1,
-        audio_concurrency: int = 1,
+        audio_concurrency: int = 0,  # Audio passthrough mode=0 (otherwise audio latency occurs)
         **init_kwargs
     ):
         """Initialize the frame processor.

--- a/pytrickle/server.py
+++ b/pytrickle/server.py
@@ -323,6 +323,7 @@ class StreamServer:
             self.current_client = TrickleClient(
                 protocol=protocol,
                 frame_processor=self.frame_processor,
+                control_handler=self._handle_control_message,
             )
             
             # Track active client and start health monitoring

--- a/pytrickle/server.py
+++ b/pytrickle/server.py
@@ -8,7 +8,8 @@ starting streams, updating parameters, and monitoring status.
 import asyncio
 import logging
 import time
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, Callable, Union, List
+from dataclasses import dataclass
 import os
 
 from aiohttp import web
@@ -22,6 +23,14 @@ from .frame_processor import FrameProcessor
 
 logger = logging.getLogger(__name__)
 
+@dataclass
+class RouteConfig:
+    """Configuration for custom routes."""
+    method: str
+    path: str
+    handler: Callable
+    kwargs: Optional[Dict[str, Any]] = None
+
 class StreamServer:
     """HTTP server application for trickle streaming with native async processor support."""
     
@@ -31,7 +40,22 @@ class StreamServer:
         port: int = 8000,
         pipeline: str = "",
         capability_name: str = "",
-        version: str = "0.0.1"
+        version: str = "0.0.1",
+        # New configurability options
+        custom_routes: Optional[List[Union[RouteConfig, Dict[str, Any]]]] = None,
+        middleware: Optional[List[Callable]] = None,
+        cors_config: Optional[Dict[str, Any]] = None,
+        static_routes: Optional[List[Dict[str, Any]]] = None,
+        app_context: Optional[Dict[str, Any]] = None,
+        health_check_interval: float = 5.0,
+        enable_default_routes: bool = True,
+        route_prefix: str = "/api",
+        host: str = "0.0.0.0",
+        # Startup/shutdown hooks
+        on_startup: Optional[List[Callable]] = None,
+        on_shutdown: Optional[List[Callable]] = None,
+        # Additional aiohttp app configuration
+        app_kwargs: Optional[Dict[str, Any]] = None
     ):
         """Initialize StreamServer.
         
@@ -40,11 +64,32 @@ class StreamServer:
             port: HTTP server port
             capability_name: Name of the capability
             version: Version string
+            custom_routes: List of custom routes to add (RouteConfig objects or dicts)
+            middleware: List of aiohttp middleware functions
+            cors_config: CORS configuration dict (requires aiohttp-cors)
+            static_routes: List of static route configurations
+            app_context: Additional context to store in the app
+            health_check_interval: Interval for health monitoring in seconds
+            enable_default_routes: Whether to enable default streaming routes
+            route_prefix: Prefix for default routes
+            host: Host to bind the server to
+            on_startup: List of startup handlers
+            on_shutdown: List of shutdown handlers
+            app_kwargs: Additional kwargs for aiohttp.web.Application
         """
         self.frame_processor = frame_processor
         self.port = port
+        self.host = host
         self.state = StreamState()
-        self.app = web.Application()
+        self.route_prefix = route_prefix
+        self.enable_default_routes = enable_default_routes
+        self.health_check_interval = health_check_interval
+        
+        # Create aiohttp application with optional configuration
+        app_config = app_kwargs or {}
+        self.app = web.Application(**app_config)
+        
+        # Store configuration
         self.current_client: Optional[TrickleClient] = None
         self.current_params: Optional[StreamStartRequest] = None
         self._health_monitor_task: Optional[asyncio.Task] = None
@@ -54,27 +99,179 @@ class StreamServer:
         self.pipeline = pipeline or os.getenv("PIPELINE", "byoc")
         self.capability_name = capability_name or os.getenv("CAPABILITY_NAME", os.getenv("MODEL_ID",""))
 
+        # Store app context
+        if app_context:
+            for key, value in app_context.items():
+                self.app[key] = value
+
+        # Setup middleware first (order matters)
+        if middleware:
+            self._setup_middleware(middleware)
+        
+        # Setup CORS if configured
+        if cors_config:
+            self._setup_cors(cors_config)
+        
+        # Setup startup/shutdown handlers
+        if on_startup:
+            for handler in on_startup:
+                self.app.on_startup.append(handler)
+        if on_shutdown:
+            for handler in on_shutdown:
+                self.app.on_shutdown.append(handler)
+
         # Setup routes
-        self._setup_routes()
+        if enable_default_routes:
+            self._setup_routes()
+        
+        # Setup custom routes
+        if custom_routes:
+            self._setup_custom_routes(custom_routes)
+        
+        # Setup static routes
+        if static_routes:
+            self._setup_static_routes(static_routes)
     
+    def _setup_middleware(self, middleware_list: List[Callable]):
+        """Setup middleware for the aiohttp application."""
+        for middleware_func in middleware_list:
+            self.app.middlewares.append(middleware_func)
+    
+    def _setup_cors(self, cors_config: Dict[str, Any]):
+        """Setup CORS configuration."""
+        try:
+            from aiohttp_cors import setup as setup_cors, ResourceOptions
+            
+            # Convert dict config to ResourceOptions if needed
+            defaults = {}
+            for origin, config in cors_config.items():
+                if isinstance(config, dict):
+                    defaults[origin] = ResourceOptions(**config)
+                else:
+                    defaults[origin] = config
+            
+            cors = setup_cors(self.app, defaults=defaults)
+            
+            # Store cors object for later use (e.g., adding routes after setup)
+            self.app['cors'] = cors
+            
+        except ImportError:
+            logger.warning("aiohttp-cors not installed, CORS configuration ignored")
+    
+    def _setup_custom_routes(self, routes: List[Union[RouteConfig, Dict[str, Any]]]):
+        """Setup custom routes."""
+        for route_config in routes:
+            if isinstance(route_config, dict):
+                # Convert dict to RouteConfig
+                kwargs = route_config.pop('kwargs', {})
+                route = RouteConfig(**route_config, kwargs=kwargs)
+            else:
+                route = route_config
+            
+            # Add the route
+            route_kwargs = route.kwargs or {}
+            route_resource = self.app.router.add_route(
+                route.method, 
+                route.path, 
+                route.handler,
+                **route_kwargs
+            )
+            
+            # Add to CORS if configured
+            if 'cors' in self.app:
+                self.app['cors'].add(route_resource)
+    
+    def _setup_static_routes(self, static_routes: List[Dict[str, Any]]):
+        """Setup static file routes."""
+        for static_config in static_routes:
+            prefix = static_config['prefix']
+            path = static_config['path']
+            kwargs = static_config.get('kwargs', {})
+            
+            static_resource = self.app.router.add_static(prefix, path, **kwargs)
+            
+            # Add to CORS if configured
+            if 'cors' in self.app:
+                self.app['cors'].add(static_resource)
+
     def _default_hardware_info(self) -> Dict[str, Any]:
         """Return default hardware info."""
         return self.hardware_info.get_gpu_compute_info()
     
     def _setup_routes(self):
-        """Setup HTTP routes."""
-        self.app.router.add_post("/api/stream/start", self._handle_start_stream)
-        self.app.router.add_post("/api/stream/stop", self._handle_stop_stream)
-        self.app.router.add_post("/api/stream/params", self._handle_update_params)
-        self.app.router.add_get("/api/stream/status", self._handle_get_status)
-        self.app.router.add_get("/health", self._handle_health)
-        self.app.router.add_get("/version", self._handle_version)
-        self.app.router.add_get("/hardware/info", self._handle_hardware_info)
-        self.app.router.add_get("/hardware/stats", self._handle_hardware_stats)
-
-        # Alias for live-video-to-video endpoint (same as stream/start)
-        self.app.router.add_post("/live-video-to-video", self._handle_start_stream)
+        """Setup default HTTP routes."""
+        prefix = self.route_prefix.rstrip('/')
+        
+        # Core streaming routes
+        stream_routes = [
+            (f"{prefix}/stream/start", self._handle_start_stream),
+            (f"{prefix}/stream/stop", self._handle_stop_stream), 
+            (f"{prefix}/stream/params", self._handle_update_params),
+            (f"{prefix}/stream/status", self._handle_get_status),
+        ]
+        
+        # System routes
+        system_routes = [
+            ("/health", self._handle_health),
+            ("/version", self._handle_version),
+            ("/hardware/info", self._handle_hardware_info),
+            ("/hardware/stats", self._handle_hardware_stats),
+        ]
+        
+        # Compatibility routes
+        compat_routes = [
+            ("/live-video-to-video", self._handle_start_stream),  # Alias for stream/start
+        ]
+        
+        # Add all routes
+        all_routes = stream_routes + system_routes + compat_routes
+        for path, handler in all_routes:
+            if path.endswith(('start', 'stop', 'params', 'live-video-to-video')):
+                route_resource = self.app.router.add_post(path, handler)
+            else:
+                route_resource = self.app.router.add_get(path, handler)
+            
+            # Add to CORS if configured
+            if 'cors' in self.app:
+                self.app['cors'].add(route_resource)
     
+    # Add new public methods for dynamic configuration
+    def add_route(self, method: str, path: str, handler: Callable, **kwargs) -> web.AbstractRoute:
+        """Add a route dynamically after initialization."""
+        route_resource = self.app.router.add_route(method, path, handler, **kwargs)
+        
+        # Add to CORS if configured
+        if 'cors' in self.app:
+            self.app['cors'].add(route_resource)
+            
+        return route_resource
+    
+    def add_static_route(self, prefix: str, path: str, **kwargs) -> web.AbstractRoute:
+        """Add a static route dynamically after initialization."""
+        static_resource = self.app.router.add_static(prefix, path, **kwargs)
+        
+        # Add to CORS if configured
+        if 'cors' in self.app:
+            self.app['cors'].add(static_resource)
+            
+        return static_resource
+    
+    def get_app(self) -> web.Application:
+        """Get the underlying aiohttp application for advanced customization."""
+        return self.app
+    
+    def add_middleware(self, middleware: Callable):
+        """Add middleware dynamically (must be called before server start)."""
+        self.app.middlewares.append(middleware)
+    
+    def set_context(self, key: str, value: Any):
+        """Set a value in the app context."""
+        self.app[key] = value
+    
+    def get_context(self, key: str, default: Any = None) -> Any:
+        """Get a value from the app context."""
+        return self.app.get(key, default)
+
     async def _parse_and_validate_request(self, request: web.Request, model_class):
         """Parse and validate request data using a Pydantic model."""
         if request.content_type.startswith("application/json"):
@@ -317,7 +514,7 @@ class StreamServer:
         """Background task to monitor component health."""
         try:
             while self.current_client:
-                await asyncio.sleep(5.0)  # Check every 5 seconds
+                await asyncio.sleep(self.health_check_interval)
                 
                 if self.current_client and self.current_client.protocol:
                     protocol = self.current_client.protocol
@@ -374,13 +571,13 @@ class StreamServer:
         runner = web.AppRunner(self.app)
         await runner.setup()
         
-        site = web.TCPSite(runner, "0.0.0.0", self.port)
+        site = web.TCPSite(runner, self.host, self.port)
         await site.start()
         
         # Set pipeline ready when server is up and ready to accept requests
         self.state.set_pipeline_ready()
         
-        logger.info(f"Trickle app server started on port {self.port}")
+        logger.info(f"Trickle app server started on {self.host}:{self.port}")
         return runner
     
     async def run_forever(self):
@@ -400,7 +597,8 @@ def create_app(
     frame_processor: 'FrameProcessor',
     port: int = 8000,
     capability_name: str = "",
-    version: str = "0.0.1"
+    version: str = "0.0.1",
+    **kwargs
 ) -> StreamServer:
     """Create a stream server instance.
 
@@ -409,6 +607,7 @@ def create_app(
         port: HTTP server port
         capability_name: Name of the capability
         version: Version string
+        **kwargs: Additional configuration options for TrickleApp
         
     Returns:
         StreamServer instance
@@ -423,5 +622,6 @@ def create_app(
         frame_processor=frame_processor,
         port=port,
         capability_name=capability_name,
-        version=version
+        version=version,
+        **kwargs
     ) 

--- a/pytrickle/state.py
+++ b/pytrickle/state.py
@@ -58,6 +58,8 @@ class StreamState:
         
         # Client tracking
         self.active_client: bool = False
+        self.active_streams: int = 0
+        self.startup_complete: bool = False
 
     # State and derived flags
     @property
@@ -102,11 +104,10 @@ class StreamState:
         # Determine status: prioritize ERROR, then "OK" if actively streaming, otherwise pipeline state
         if self.error_event.is_set():
             status = "ERROR"
-        elif self._state is PipelineState.READY and self.active_client:
+        elif self._state is PipelineState.READY and (self.active_client or self.active_streams > 0):
             status = "OK"
         else:
             status = self._state.value
-            
         return {
             "status": status,
             "pipeline_ready": self.pipeline_ready,
@@ -186,3 +187,43 @@ class StreamState:
             self._reset_to_init()
         else:
             logger.warning(f"Unknown PipelineState enum: {state}")
+
+    # ---- Unified health-style API (to replace StreamHealthManager)
+    def set_startup_complete(self) -> None:
+        """Mark startup as complete for health/status reporting."""
+        self.startup_complete = True
+        # If no explicit state chosen yet, move from INIT -> LOADING
+        if self._state is PipelineState.INIT:
+            self._state = PipelineState.LOADING
+            self.running_event.set()
+
+    def update_active_streams(self, count: int) -> None:
+        """Update number of active streams for health/status reporting."""
+        self.active_streams = max(0, int(count))
+
+    def is_error(self) -> bool:
+        return self.error_event.is_set()
+
+    @property
+    def pipeline_warming(self) -> bool:
+        return self._state is PipelineState.WARMING_PIPELINE
+
+    def get_pipeline_state(self) -> dict:
+        """Return health-like payload used by /health endpoint."""
+        # If startup not complete, always show LOADING
+        if not self.startup_complete:
+            outward = "LOADING"
+        elif self._state is PipelineState.READY:
+            outward = "OK" if self.active_streams > 0 else "IDLE"
+        else:
+            outward = self._state.value
+        return {
+            "status": outward,  # backward-compatible key
+            "state": outward,
+            "error_message": None,  # keep compatibility with previous health payload
+            "pipeline_ready": self._state is PipelineState.READY,
+            "active_streams": self.active_streams,
+            "startup_complete": self.startup_complete,
+            "pipeline_state": self._state.name,
+            "additional_info": {},
+        }

--- a/tests/test_prompt_validation.py
+++ b/tests/test_prompt_validation.py
@@ -1,0 +1,482 @@
+"""
+Tests for prompt parsing and validation functionality.
+
+Tests the centralized prompt validation system in comfystream that handles
+prompts from various sources. Tests the core validation logic and integration
+with server endpoints, but not the pytrickle API models themselves.
+"""
+
+import json
+import pytest
+import logging
+from pytrickle.api import (
+    validate_prompts_for_api,
+    parse_prompts_field,
+    extract_prompts_from_params,
+)
+
+# Set up logging to show validation in action
+logging.basicConfig(level=logging.INFO, format='🔍 %(levelname)s: %(message)s')
+logger = logging.getLogger(__name__)
+
+# Test prompt data - simulates real ComfyUI workflows
+SIMPLE_WORKFLOW = {
+    "1": {
+        "inputs": {
+            "images": ["2", 0]
+        },
+        "class_type": "SaveTensor",
+        "_meta": {
+            "title": "SaveTensor"
+        }
+    },
+    "2": {
+        "inputs": {},
+        "class_type": "LoadTensor",
+        "_meta": {
+            "title": "LoadTensor"
+        }
+    }
+}
+
+COMPLEX_WORKFLOW = {
+    "1": {
+        "inputs": {
+            "text": "a beautiful landscape",
+            "clip": ["2", 0]
+        },
+        "class_type": "CLIPTextEncode",
+        "_meta": {"title": "CLIP Text Encode (Prompt)"}
+    },
+    "2": {
+        "inputs": {
+            "ckpt_name": "v1-5-pruned-emaonly.ckpt"
+        },
+        "class_type": "CheckpointLoaderSimple",
+        "_meta": {"title": "Load Checkpoint"}
+    },
+    "3": {
+        "inputs": {
+            "seed": 42,
+            "steps": 20,
+            "cfg": 8.0,
+            "sampler_name": "euler",
+            "scheduler": "normal",
+            "denoise": 1.0,
+            "model": ["2", 0],
+            "positive": ["1", 0],
+            "negative": ["4", 0],
+            "latent_image": ["5", 0]
+        },
+        "class_type": "KSampler",
+        "_meta": {"title": "KSampler"}
+    },
+    "4": {
+        "inputs": {
+            "text": "",
+            "clip": ["2", 0]
+        },
+        "class_type": "CLIPTextEncode",
+        "_meta": {"title": "CLIP Text Encode (Negative)"}
+    },
+    "5": {
+        "inputs": {
+            "width": 512,
+            "height": 512,
+            "batch_size": 1
+        },
+        "class_type": "EmptyLatentImage",
+        "_meta": {"title": "Empty Latent Image"}
+    }
+}
+
+AUDIO_WORKFLOW = {
+    "1": {
+        "inputs": {},
+        "class_type": "LoadAudioTensor",
+        "_meta": {"title": "LoadAudioTensor"}
+    },
+    "2": {
+        "inputs": {
+            "audio": ["1", 0],
+            "gain": 1.0
+        },
+        "class_type": "AudioGain",
+        "_meta": {"title": "Audio Gain"}
+    },
+    "3": {
+        "inputs": {
+            "audio": ["2", 0]
+        },
+        "class_type": "SaveAudioTensor",
+        "_meta": {"title": "SaveAudioTensor"}
+    }
+}
+
+class TestPromptValidationCore:
+    """Test core prompt validation functionality."""
+    
+    def test_import_validation_functions(self):
+        """Test that prompt validation functions can be imported."""
+        assert callable(validate_prompts_for_api)
+        assert callable(extract_prompts_from_params)
+    
+    def test_validate_single_prompt_dict(self):
+        """Test validation of a single prompt dictionary."""
+        logger.info("🎯 Testing single prompt dictionary validation...")
+        
+        logger.info("✅ Using pytrickle validation module")
+        
+        logger.info(f"📝 Input: Workflow with {len(SIMPLE_WORKFLOW)} nodes")
+        result = validate_prompts_for_api(SIMPLE_WORKFLOW)
+        logger.info(f"✅ Output: {len(result)} validated prompt(s)")
+        
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0] == SIMPLE_WORKFLOW
+        logger.info("🎉 Single prompt dictionary validation PASSED!")
+    
+    def test_validate_prompt_list(self):
+        """Test validation of a list of prompt dictionaries."""
+        
+        prompt_list = [SIMPLE_WORKFLOW, COMPLEX_WORKFLOW]
+        result = validate_prompts_for_api(prompt_list)
+        
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0] == SIMPLE_WORKFLOW
+        assert result[1] == COMPLEX_WORKFLOW
+    
+    def test_validate_json_string_single_prompt(self):
+        """Test validation of JSON string containing single prompt."""
+        logger.info("🎯 Testing JSON string prompt validation...")
+        
+        logger.info("✅ Using pytrickle validation module")
+        
+        json_string = json.dumps(SIMPLE_WORKFLOW)
+        logger.info(f"📝 Input: JSON string ({len(json_string)} chars)")
+        logger.info(f"🔤 JSON Preview: {json_string[:50]}...")
+        
+        result = validate_prompts_for_api(json_string)
+        logger.info(f"✅ Output: {len(result)} validated prompt(s)")
+        logger.info("🔄 JSON → Dict conversion successful!")
+        
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0] == SIMPLE_WORKFLOW
+        logger.info("🎉 JSON string validation PASSED!")
+    
+    def test_validate_json_string_prompt_list(self):
+        """Test validation of JSON string containing list of prompts."""
+        
+        prompt_list = [SIMPLE_WORKFLOW, AUDIO_WORKFLOW]
+        json_string = json.dumps(prompt_list)
+        result = validate_prompts_for_api(json_string)
+        
+        assert isinstance(result, list)
+        assert len(result) == 2
+        assert result[0] == SIMPLE_WORKFLOW
+        assert result[1] == AUDIO_WORKFLOW
+    
+    def test_validate_mixed_json_strings_in_list(self):
+        """Test validation of list containing both dicts and JSON strings."""
+        logger.info("🎯 Testing MIXED list validation (dicts + JSON strings)...")
+        
+        logger.info("✅ Using pytrickle parse_prompts_field")
+        
+        # Test directly with the parse function that handles mixed types
+        mixed_list = [
+            json.dumps(SIMPLE_WORKFLOW),  # JSON string
+            COMPLEX_WORKFLOW,             # Dict
+            json.dumps(AUDIO_WORKFLOW)    # JSON string
+        ]
+        
+        logger.info("📝 Input: Mixed list with 3 items:")
+        logger.info("   📄 [0]: JSON string (SIMPLE_WORKFLOW)")
+        logger.info("   📊 [1]: Dict object (COMPLEX_WORKFLOW)")  
+        logger.info("   📄 [2]: JSON string (AUDIO_WORKFLOW)")
+        
+        result = parse_prompts_field(mixed_list)
+        
+        logger.info(f"✅ Output: {len(result)} parsed prompts")
+        logger.info("🔄 Mixed format parsing successful!")
+        
+        assert isinstance(result, list)
+        assert len(result) == 3
+        assert result[0] == SIMPLE_WORKFLOW
+        assert result[1] == COMPLEX_WORKFLOW
+        assert result[2] == AUDIO_WORKFLOW
+        logger.info("🎉 Mixed format validation PASSED!")
+    
+    def test_invalid_prompt_formats(self):
+        """Test validation with invalid prompt formats."""
+        
+        # Test invalid types
+        with pytest.raises(ValueError, match="Invalid prompts"):
+            validate_prompts_for_api(123)
+        
+        with pytest.raises(ValueError, match="Invalid prompts"):
+            validate_prompts_for_api(True)
+        
+        with pytest.raises(ValueError, match="Invalid prompts"):
+            validate_prompts_for_api(None)
+    
+    def test_invalid_json_strings(self):
+        """Test validation with invalid JSON strings."""
+        
+        # Invalid JSON
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            validate_prompts_for_api('{"invalid": json}')
+        
+        # JSON with invalid structure
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            validate_prompts_for_api('{"unclosed": "dict"')
+    
+    def test_empty_prompts_validation(self):
+        """Test validation with empty prompt structures."""
+        
+        # Empty dict
+        with pytest.raises(ValueError, match="cannot be empty"):
+            validate_prompts_for_api({})
+        
+        # Empty list
+        with pytest.raises(ValueError, match="cannot be empty"):
+            validate_prompts_for_api([])
+    
+    def test_invalid_prompt_structure(self):
+        """Test validation with invalid ComfyUI prompt structure."""
+        
+        # Missing class_type
+        invalid_prompt = {
+            "1": {
+                "inputs": {},
+                "_meta": {"title": "Test"}
+                # Missing class_type
+            }
+        }
+        
+        with pytest.raises(ValueError, match="Invalid prompts"):
+            validate_prompts_for_api(invalid_prompt)
+        
+        # Non-string node ID
+        invalid_prompt_2 = {
+            123: {  # Should be string
+                "inputs": {},
+                "class_type": "TestNode",
+                "_meta": {"title": "Test"}
+            }
+        }
+        
+        with pytest.raises(ValueError, match="Invalid prompts"):
+            validate_prompts_for_api(invalid_prompt_2)
+        
+        # Non-dict node data
+        invalid_prompt_3 = {
+            "1": "not_a_dict"  # Should be dict
+        }
+        
+        with pytest.raises(ValueError, match="Invalid prompts"):
+            validate_prompts_for_api(invalid_prompt_3)
+
+
+class TestComfyStreamServerIntegration:
+    """Test prompt validation integration with ComfyStream server endpoints."""
+    
+    def test_server_endpoint_prompt_validation(self):
+        """Test that server endpoints can validate prompts using pytrickle validation."""
+        logger.info("🎯 Testing SERVER ENDPOINT integration...")
+        
+        logger.info("✅ pytrickle validation available for server")
+        
+        # Simulate server endpoint receiving prompts
+        incoming_params = {
+            "prompts": json.dumps(SIMPLE_WORKFLOW),
+            "width": 512,
+            "height": 512
+        }
+        
+        logger.info("🌐 Simulating server receiving request:")
+        logger.info(f"   📏 width: {incoming_params['width']}")
+        logger.info(f"   📏 height: {incoming_params['height']}")
+        logger.info(f"   📝 prompts: JSON string ({len(incoming_params['prompts'])} chars)")
+        
+        # Validate prompts as server would
+        logger.info("🔍 Server validating prompts...")
+        validated_prompts = validate_prompts_for_api(incoming_params["prompts"])
+        
+        logger.info(f"✅ Server validation result: {len(validated_prompts)} validated prompt(s)")
+        logger.info("🎯 Server endpoint integration working!")
+        
+        assert isinstance(validated_prompts, list)
+        assert len(validated_prompts) == 1
+        assert validated_prompts[0] == SIMPLE_WORKFLOW
+        logger.info("🎉 Server endpoint validation PASSED!")
+    
+    def test_server_endpoint_error_handling(self):
+        """Test server endpoint error handling for invalid prompts."""
+        
+        # Simulate server receiving invalid prompts
+        invalid_params = {
+            "prompts": "invalid json",
+            "width": 512,
+            "height": 512
+        }
+        
+        with pytest.raises(ValueError):
+            validate_prompts_for_api(invalid_params["prompts"])
+
+
+class TestPromptValidationIntegration:
+    """Test integration scenarios with prompt validation."""
+    
+    def test_extract_prompts_from_params_function(self):
+        """Test the extract_prompts_from_params utility function."""
+        
+        # Test with prompts
+        params_with_prompts = {
+            "prompts": SIMPLE_WORKFLOW,
+            "width": 512,
+            "height": 512
+        }
+        
+        result = extract_prompts_from_params(params_with_prompts)
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0] == SIMPLE_WORKFLOW
+        
+        # Test without prompts
+        params_without_prompts = {
+            "width": 512,
+            "height": 512,
+            "intensity": 0.8
+        }
+        
+        result = extract_prompts_from_params(params_without_prompts)
+        assert result is None
+    
+    def test_prompt_validation_consistency(self):
+        """Test consistent prompt validation across different input formats."""
+            
+        test_prompts = [SIMPLE_WORKFLOW, AUDIO_WORKFLOW]
+        
+        # Test as list
+        result1 = validate_prompts_for_api(test_prompts)
+        
+        # Test as JSON string  
+        result2 = validate_prompts_for_api(json.dumps(test_prompts))
+        
+        # Both should be equivalent
+        assert result1 == result2
+        assert len(result1) == 2
+        assert len(result2) == 2
+    
+    def test_real_world_workflow_validation(self):
+        """Test with realistic ComfyUI workflow scenarios."""
+        logger.info("🎯 Testing REAL-WORLD ComfyUI workflow validation...")
+        
+        logger.info("✅ pytrickle validation available")
+            
+        logger.info("🎨 Creating realistic Stable Diffusion workflow...")
+        # Simulate a real SD workflow from ComfyUI
+        realistic_sd_workflow = {
+            "1": {
+                "inputs": {
+                    "ckpt_name": "sd_xl_base_1.0.safetensors"
+                },
+                "class_type": "CheckpointLoaderSimple",
+                "_meta": {"title": "Load Checkpoint - BASE"}
+            },
+            "2": {
+                "inputs": {
+                    "text": "a majestic mountain landscape at sunset, highly detailed, 8k",
+                    "clip": ["1", 1]
+                },
+                "class_type": "CLIPTextEncode",
+                "_meta": {"title": "CLIP Text Encode (Prompt)"}
+            },
+            "3": {
+                "inputs": {
+                    "text": "blurry, low quality, distorted",
+                    "clip": ["1", 1]
+                },
+                "class_type": "CLIPTextEncode",
+                "_meta": {"title": "CLIP Text Encode (Negative)"}
+            },
+            "4": {
+                "inputs": {
+                    "width": 1024,
+                    "height": 1024,
+                    "batch_size": 1
+                },
+                "class_type": "EmptyLatentImage",
+                "_meta": {"title": "Empty Latent Image"}
+            },
+            "5": {
+                "inputs": {
+                    "seed": 42,
+                    "steps": 30,
+                    "cfg": 7.5,
+                    "sampler_name": "dpmpp_2m",
+                    "scheduler": "karras",
+                    "denoise": 1.0,
+                    "model": ["1", 0],
+                    "positive": ["2", 0],
+                    "negative": ["3", 0],
+                    "latent_image": ["4", 0]
+                },
+                "class_type": "KSampler",
+                "_meta": {"title": "KSampler"}
+            }
+        }
+        
+        logger.info(f"📊 Workflow stats: {len(realistic_sd_workflow)} nodes")
+        logger.info("   🔧 CheckpointLoaderSimple (model loading)")
+        logger.info("   ✏️  CLIPTextEncode (positive prompt)")
+        logger.info("   ⛔ CLIPTextEncode (negative prompt)")
+        logger.info("   🖼️  EmptyLatentImage (canvas)")
+        logger.info("   🎲 KSampler (generation)")
+        
+        # Test validation
+        logger.info("🔍 Validating complex SD workflow...")
+        validated_prompts = validate_prompts_for_api(realistic_sd_workflow)
+        
+        logger.info(f"✅ Validation result: {len(validated_prompts)} validated prompt(s)")
+        logger.info("🎨 Complex workflow validation successful!")
+        
+        assert isinstance(validated_prompts, list)
+        assert len(validated_prompts) == 1
+        assert "CheckpointLoaderSimple" in str(validated_prompts[0])
+        assert "KSampler" in str(validated_prompts[0])
+        logger.info("🎉 Real-world workflow validation PASSED!")
+    
+    def test_error_handling_with_partial_valid_data(self):
+        """Test error handling when some data is valid but prompts are invalid."""
+            
+        # Test invalid JSON should raise error
+        with pytest.raises(ValueError):
+            validate_prompts_for_api('{"invalid": json syntax}')
+
+
+class TestBackwardCompatibility:
+    """Test backward compatibility with existing prompt parsing functions."""
+    
+    def test_parsing_functions_handle_legacy_formats(self):
+        """Test that prompt parsing functions handle various legacy formats."""
+        
+        # Test various formats that might come from different sources
+        formats_to_test = [
+            SIMPLE_WORKFLOW,  # Direct dict
+            [SIMPLE_WORKFLOW],  # List of dicts
+            json.dumps(SIMPLE_WORKFLOW),  # JSON string
+            json.dumps([SIMPLE_WORKFLOW])  # JSON string of list
+        ]
+        
+        for test_format in formats_to_test:
+            result = parse_prompts_field(test_format)
+            assert isinstance(result, list)
+            assert len(result) == 1
+            assert result[0] == SIMPLE_WORKFLOW
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
This pull request introduces a new minimal async output drain example and significantly refactors the `pytrickle` client to better support asynchronous processing using internal queues, background worker tasks, and improved audio/video handling. The changes enable more robust and scalable processing pipelines, especially when using custom `FrameProcessor` implementations in queue mode.

Key changes include:

**New Example and Documentation:**
* Added `async_output_drain_example.py`, demonstrating a minimal async `FrameProcessor` in queue mode with an output drain pattern, including a custom video tint and audio passthrough.

**Async Queue and Output Handling:**
* Replaced the synchronous `queue.Queue` with `asyncio.Queue` for `output_queue` in `TrickleClient`, ensuring full async compatibility and improving throughput.
* Introduced a background drain task (`_processor_drain_task`) that pulls processed frames from the `FrameProcessor` and pushes them into the output queue, decoupling ingress and egress. [[1]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabL53-R61) [[2]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabR322-R373) [[3]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabR285-L219)
* Updated egress and output sending logic to use asyncio-native methods and exceptions, improving reliability and error handling. [[1]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabR285-L219) [[2]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabL275-R448)

**FrameProcessor Queue Mode Integration:**
* On client start, automatically starts frame processor queue workers if `queue_mode` is enabled, and ensures workers are properly stopped and cleaned up on shutdown. [[1]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabR83-R90) [[2]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabL116-R183)
* In the ingress loop, routes frames to the processor's input queues or processes them directly depending on the mode and audio concurrency, supporting both async and passthrough flows. [[1]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabL137-R204) [[2]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabL149-R231)

**Control and State Management:**
* Added built-in handling for processor control commands (start/stop workers, reset timing/state, pause/resume inputs) in the control message handler, improving remote manageability.
* Added a `_reset_timing_state` method to clear client-side timing state between streams, preventing A/V sync issues.

**Other Improvements:**
* Updated module docstring in `frame_processor.py` to document new queue mode and worker enhancements.
* Removed unused imports and cleaned up minor code paths for clarity.

These changes collectively make the async processing pipeline more robust, flexible, and easier to extend for advanced use cases.

--- 

**References:**  
[[1]](diffhunk://#diff-ce1fd0aea6bb1ac4383f18bc6acd536f0412ba25555ed1636d575733915c0d03R1-R160) [[2]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabL53-R61) [[3]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabR322-R373) [[4]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabR285-L219) [[5]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabL275-R448) [[6]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabR83-R90) [[7]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabL116-R183) [[8]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabL137-R204) [[9]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabL149-R231) [[10]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabR400-R434) [[11]](diffhunk://#diff-621c8f59d421cc471eebc5bbe6ad784b70f20aa83746250bb4f13a092b8c2cd9R5-R13) [[12]](diffhunk://#diff-ac949759384406e02e25163fa4aa9e327be1522a9317daed516ed4da7224aeabL9)