### PR TITLE
encoder: set default image tensor format to match decoder (RGB)

### DIFF
--- a/pytrickle/encoder.py
+++ b/pytrickle/encoder.py
@@ -145,7 +145,8 @@ def encode_av(
 
             tensor = avframe.tensor.squeeze(0)
             image_np = (tensor * 255).byte().cpu().numpy()
-            image = Image.fromarray(image_np)
+            # Explicitly specify RGB mode - decoder produces RGB, encoder expects RGB
+            image = Image.fromarray(image_np, mode='RGB')
 
             frame = av.video.frame.VideoFrame.from_image(image)
             


### PR DESCRIPTION
This pull request makes a small but important change to how images are handled during encoding. The change explicitly specifies the RGB mode when creating a `PIL.Image` from a NumPy array to ensure color consistency between the decoder and encoder.

* Explicitly set the `mode='RGB'` when creating a `PIL.Image` from the NumPy array in `custom_io_open`, ensuring the encoder receives images in the correct color format.