### PR TITLE
add async for param_updater and model_loader

### DIFF
--- a/examples/process_video_example.py
+++ b/examples/process_video_example.py
@@ -23,7 +23,7 @@ processor = None
 background_tasks = []
 background_task_started = False
 
-def load_model(**kwargs):
+async def load_model(**kwargs):
     """Initialize processor state - called during model loading phase."""
     global intensity, ready, processor
     
@@ -185,7 +185,7 @@ async def process_video(frame: VideoFrame) -> VideoFrame:
     
     return frame.replace_tensor(result_tensor)
 
-def update_params(params: dict):
+async def update_params(params: dict):
     """Update green hue intensity (0.0 to 1.0)."""
     global intensity, delay
     if "intensity" in params:

--- a/pytrickle/frame_processor.py
+++ b/pytrickle/frame_processor.py
@@ -55,39 +55,10 @@ class FrameProcessor(ABC):
         """
         self.error_callback = error_callback
         self.state: Optional[StreamState] = None
-        self.model_loaded: bool = False
-        # Note: load_model is now async but __init__ cannot be async
-        # The actual loading will be done when the processor is first used
-        # or when explicitly called via load_model_async()
-
-    async def load_model_async(self, **kwargs) -> None:
-        """
-        Load the model asynchronously.
-
-        This method should be implemented to load any required models or resources.
-        It is called automatically when needed.
-        
-        Args:
-            **kwargs: Additional parameters for model loading
-        """
-        try:
-            self.state.set_state(PipelineState.LOADING)
-            await self.load_model(**kwargs)
-            self.model_loaded = True
-            # If a state manager is already attached, mark ready automatically
-            if self.state is not None:
-                self.state.set_state(PipelineState.IDLE)
-        except Exception:
-            # If load fails and we have a state manager, mark ERROR
-            if self.state is not None:
-                self.state.set_state(PipelineState.ERROR)
-            raise
 
     def attach_state(self, state: StreamState) -> None:
         """Attach a pipeline state manager and set IDLE if model already loaded."""
         self.state = state
-        if self.model_loaded:
-            self.state.set_state(PipelineState.IDLE)
 
     @abstractmethod
     async def load_model(self, **kwargs):

--- a/pytrickle/server.py
+++ b/pytrickle/server.py
@@ -340,7 +340,7 @@ class StreamServer:
             # Set params if provided
             if params.params:
                 try:
-                    self.frame_processor.update_params(params.params)
+                    await self.frame_processor.update_params(params.params)
                 except Exception as e:
                     logger.warning(f"Failed to set params: {e}")
             
@@ -416,7 +416,7 @@ class StreamServer:
         Routes control messages to the frame processor's update_params method.
         """
         try:
-            self.frame_processor.update_params(control_data)
+            await self.frame_processor.update_params(control_data)
             logger.debug("Control message routed to frame processor")
         except Exception as e:
             logger.error(f"Error handling control message: {e}")
@@ -435,7 +435,7 @@ class StreamServer:
                 }, status=400)
             
             # Update frame processor parameters
-            self.frame_processor.update_params(data)
+            await self.frame_processor.update_params(data)
             logger.info(f"Parameters updated: {data}")
             
             # Emit monitoring event
@@ -620,7 +620,7 @@ class StreamServer:
         self.state.set_state(PipelineState.IDLE)
         self.state.set_startup_complete()
         
-        logger.info(f"Trickle app server started on {self.host}:{self.port}")
+        logger.info(f"Server started on {self.host}:{self.port}")
         return runner
 
     # Built-in State Management API

--- a/pytrickle/test_utils.py
+++ b/pytrickle/test_utils.py
@@ -18,7 +18,7 @@ class MockFrameProcessor(FrameProcessor):
         self.test_params = {}
         super().__init__(**kwargs)
     
-    def load_model(self, **kwargs):
+    async def load_model(self, **kwargs):
         """Test model loader."""
         pass
     
@@ -30,7 +30,7 @@ class MockFrameProcessor(FrameProcessor):
         """Test audio processor."""
         return [frame]
     
-    def update_params(self, params: Dict[str, Any]):
+    async def update_params(self, params: Dict[str, Any]):
         """Test parameter updater."""
         if params:
             self.test_params.update(params)

--- a/tests/test_state_integration.py
+++ b/tests/test_state_integration.py
@@ -190,31 +190,33 @@ class TestFrameProcessorStateIntegration:
         processor.attach_state(state)
         assert processor.state is state
 
-    def test_frame_processor_model_loading_success(self):
+    @pytest.mark.asyncio
+    async def test_frame_processor_model_loading_success(self):
         """Test frame processor model loading with state updates."""
         processor = MockFrameProcessor()
         state = StreamState()
         processor.attach_state(state)
         
         # Model loading should work without errors
-        processor.load_model()
+        await processor.load_model()
         # MockFrameProcessor doesn't change state, but real ones would
 
-    def test_frame_processor_model_loading_failure(self):
+    @pytest.mark.asyncio
+    async def test_frame_processor_model_loading_failure(self):
         """Test frame processor handles model loading failures."""
         processor = MockFrameProcessor()
         state = StreamState()
         processor.attach_state(state)
         
         # Mock a failing load_model
-        def failing_load_model(**kwargs):
+        async def failing_load_model(**kwargs):
             raise Exception("Model loading failed")
         
         processor.load_model = failing_load_model
         
         # Should handle the exception gracefully
         try:
-            processor.load_model()
+            await processor.load_model()
             assert False, "Expected exception"
         except Exception as e:
             assert "Model loading failed" in str(e)
@@ -236,10 +238,10 @@ class TestFrameProcessorStateIntegration:
         processor.attach_state(state)
         
         # Test model loading
-        processor.load_model()
+        await processor.load_model()
         
         # Test parameter updates
-        processor.update_params({"intensity": 0.8})
+        await processor.update_params({"intensity": 0.8})
 
 
 class TestServerStateIntegration:
@@ -423,11 +425,11 @@ class TestStateIntegrationWithStreamProcessor:
         assert processor.state is state
         
         # Test model loading
-        processor.load_model()
+        await processor.load_model()
         
         # Test parameter updates
         test_params = {"intensity": 0.7, "effect": "test"}
-        processor.update_params(test_params)
+        await processor.update_params(test_params)
         
         # Verify processor handled params (internal behavior may vary)
         # The important thing is no exceptions were raised


### PR DESCRIPTION
This PR changes the `param_updater` (update_params) and `model_loader` (load_model) callback in StreamProcessor and the FrameProcessor abstract class to by async only. 

This has been tested in the updated `process_video_example.py` and is used within comfystream to perform async warmup and async param updates to the pipeline

https://github.com/livepeer/pytrickle/blob/bdca8f38d89be17db5185ef388e27bfcfc9f3a2a/examples/process_video_example.py#L188

https://github.com/livepeer/pytrickle/blob/bdca8f38d89be17db5185ef388e27bfcfc9f3a2a/examples/process_video_example.py#L26