### PR TITLE
use semantic versioning for pkg and /version, add /app-version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,15 +13,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Fetch full git history for setuptools-scm
 
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
-      - name: Install dependencies
+      - name: Install build dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install setuptools-scm[toml] build
+
+      - name: Install package in development mode
+        run: |
           pip install -e .[dev,examples]
 
       - name: Run pytest

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ __pycache__/
 *.egg-info
 
 build/*
+
+# Auto-generated version files
+pytrickle/_version.py

--- a/examples/process_video_example.py
+++ b/examples/process_video_example.py
@@ -207,6 +207,7 @@ if __name__ == "__main__":
         param_updater=update_params,
         on_stream_stop=on_stream_stop,
         name="green-processor",
-        port=8000
+        port=8000,
+        version="0.0.1"
     )
     processor.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytrickle"
-version = "0.1.1"
 description = "High-performance Python package for real-time video streaming over trickle protocol"
 readme = "README.md"
 license = {text = "MIT"}
@@ -30,7 +29,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 requires-python = ">=3.8"
-dynamic = ["dependencies", "optional-dependencies"]
+dynamic = ["dependencies", "optional-dependencies", "version"]
 
 [project.urls]
 Homepage = "https://github.com/livepeer/pytrickle"
@@ -122,3 +121,8 @@ module = [
     "pynvml.*",
 ]
 ignore_missing_imports = true
+
+[tool.setuptools_scm]
+# Enable setuptools-scm for automatic version management from Git tags
+write_to = "pytrickle/_version.py"
+fallback_version = "0.0.0"

--- a/pytrickle/__init__.py
+++ b/pytrickle/__init__.py
@@ -30,8 +30,7 @@ from .stream_processor import StreamProcessor
 from .fps_meter import FPSMeter
 
 from . import api
-
-__version__ = "0.1.1"
+from .version import __version__
 
 __all__ = [
     "TrickleClient",
@@ -56,5 +55,6 @@ __all__ = [
     "api",
     "ErrorCallback",
     "FrameProcessor",
-    "FPSMeter"
+    "FPSMeter",
+    "__version__"
 ] 

--- a/pytrickle/server.py
+++ b/pytrickle/server.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass
 import os
 
 from aiohttp import web
-
+from .version import __version__
 
 from .api import StreamParamsUpdateRequest, StreamStartRequest, Version, HardwareInformation, HardwareStats
 from .state import StreamState, PipelineState
@@ -227,6 +227,7 @@ class StreamServer:
         system_routes = [
             ("/health", self._handle_health),
             ("/version", self._handle_version),
+            ("/app-version", self._handle_app_version),
             ("/hardware/info", self._handle_hardware_info),
             ("/hardware/stats", self._handle_hardware_stats),
         ]
@@ -525,12 +526,18 @@ class StreamServer:
             }, status=500)
     
     async def _handle_version(self, request: web.Request) -> web.Response:
-        """Handle health check requests."""
+        """Handle version requests - returns package version."""
         return web.json_response(Version(
             pipeline=self.pipeline,
             model_id=self.capability_name,
-            version=self.version
+            version=__version__
         ).model_dump())
+    
+    async def _handle_app_version(self, request: web.Request) -> web.Response:
+        """Handle app version requests - returns customizable application version."""
+        return web.json_response({
+            "version": self.version
+        })
     
     async def _handle_hardware_info(self, request: web.Request) -> web.Response:
         """Handle hardware info requests."""

--- a/pytrickle/version.py
+++ b/pytrickle/version.py
@@ -1,0 +1,9 @@
+"""
+Version management for pytrickle package.
+
+This module provides version information used by both __init__.py and server.py.
+"""
+
+# Import from generated _version.py file (created by setuptools-scm)
+from ._version import version as __version__
+VERSION = __version__

--- a/tests/test_system_endpoints.py
+++ b/tests/test_system_endpoints.py
@@ -88,15 +88,14 @@ class TestVersionEndpoint:
         resp = await client.get("/version")
         assert resp.status == 200
         data = await resp.json()
-        assert data == {
-            "pipeline": "byoc",
-            "model_id": "trickle-stream-example",
-            "version": "0.0.1",
-        }
+        assert data["pipeline"] == "byoc"
+        assert data["model_id"] == "trickle-stream-example"
+        # Version should start with 0.1. (setuptools-scm generates versions like 0.1.4.dev0+...)
+        assert data["version"].startswith("0.1.")
 
     @pytest.mark.asyncio
     async def test_version_endpoint_custom_values(self):
-        """Test /version endpoint with custom pipeline and version values."""
+        """Test /version and /app-version endpoints with custom pipeline and version values."""
         # Create server with custom values
         processor = _InternalFrameProcessor(
             video_processor=process_video,
@@ -120,14 +119,34 @@ class TestVersionEndpoint:
         async with test_server_instance:
             client = TestClient(test_server_instance)
             async with client:
+                # Test /version endpoint returns package version
                 resp = await client.get("/version")
                 assert resp.status == 200
                 data = await resp.json()
+                assert data["pipeline"] == "custom-pipeline"
+                assert data["model_id"] == "custom-model"
+                # Version should start with 0.1. (setuptools-scm generates versions like 0.1.4.dev0+...)
+                assert data["version"].startswith("0.1.")
+                
+                # Test /app-version endpoint returns custom app version
+                resp = await client.get("/app-version")
+                assert resp.status == 200
+                data = await resp.json()
                 assert data == {
-                    "pipeline": "custom-pipeline",
-                    "model_id": "custom-model",
-                    "version": "1.2.3",
+                    "version": "1.2.3",  # Custom app version
                 }
+    
+    @pytest.mark.asyncio
+    async def test_app_version_endpoint(self, test_server):
+        """Test /app-version endpoint returns expected payload."""
+        client, server = test_server
+        
+        resp = await client.get("/app-version")
+        assert resp.status == 200
+        data = await resp.json()
+        assert data == {
+            "version": "0.0.1",  # Default app version from server init
+        }
 
 
 class TestHealthEndpointStateValidation:


### PR DESCRIPTION
This pull request introduces automatic version management for the `pytrickle` package using `setuptools-scm`, improves how version information is handled and exposed in the codebase, and enhances the API with a new `/app-version` endpoint. It also updates tests to reflect these changes and ensures version consistency throughout the project.

**Version management improvements:**

* Switched to `setuptools-scm` for automatic versioning based on Git tags, updating `pyproject.toml` and adding a `version.py` module to import the generated version. The `__version__` attribute is now imported from `version.py` instead of being hardcoded. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L7) [[2]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L33-R32) [[3]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R124-R128) [[4]](diffhunk://#diff-cf5dae3a28d3e5ec2a8488068f3a13dfe3f0be0e576c90c59caa6a0d7f9c3926R1-R9) [[5]](diffhunk://#diff-9a8af55b7bfed6dcc9dde200e3d2465808433e271140a991b9557d481a715581L36-R36) [[6]](diffhunk://#diff-9a8af55b7bfed6dcc9dde200e3d2465808433e271140a991b9557d481a715581L62-R62) [[7]](diffhunk://#diff-9c70bc53eb5e06f7b605ed06859fcc90104637db1e6e0bb5496f15957acd732dL16-R16)

**API enhancements:**

* Added a new `/app-version` endpoint to the server, which returns the application version specified at initialization, separate from the package version. The `/version` endpoint now always returns the package version from `setuptools-scm`. [[1]](diffhunk://#diff-9c70bc53eb5e06f7b605ed06859fcc90104637db1e6e0bb5496f15957acd732dR230) [[2]](diffhunk://#diff-9c70bc53eb5e06f7b605ed06859fcc90104637db1e6e0bb5496f15957acd732dL528-R541) [[3]](diffhunk://#diff-df83ff9b2b7166ad7b9b6294775c17077fef32f256aec0aaff7729c04dc258b4L148-R149)

**Testing updates:**

* Updated and expanded tests in `tests/test_system_endpoints.py` to check both the `/version` and `/app-version` endpoints, verifying correct version values and payloads. [[1]](diffhunk://#diff-af2f9cbfa473d5332368c7f8dc6f4d960ef464f7ec82e425f10572899ab226b7L91-R98) [[2]](diffhunk://#diff-af2f9cbfa473d5332368c7f8dc6f4d960ef464f7ec82e425f10572899ab226b7R122-R148)