### PR TITLE
fix (stream_processor): Remove self._ready to fix stuck passthrough

### DIFF
--- a/pytrickle/stream_processor.py
+++ b/pytrickle/stream_processor.py
@@ -134,7 +134,7 @@ class _InternalFrameProcessor(FrameProcessor):
     async def process_video_async(self, frame: VideoFrame) -> Optional[VideoFrame]:
         """Process video frame using provided async function."""
         if not self.video_processor:
-            logger.info("No video processor defined, passing frame unchanged")
+            logger.debug("No video processor defined, passing frame unchanged")
             return frame
         
         try:
@@ -147,6 +147,7 @@ class _InternalFrameProcessor(FrameProcessor):
     async def process_audio_async(self, frame: AudioFrame) -> Optional[List[AudioFrame]]:
         """Process audio frame using provided async function."""
         if not self.audio_processor:
+            logger.debug("No audio processor defined, passing frame unchanged")
             return [frame]
             
         try:


### PR DESCRIPTION
This pull request fixes an issue with the frame_processor always passing through frames due to load_model missing _ready=True from #23

This ready variable duplicates the server health state and was intended to be removed, this change cleans up the remaining bits to fix the permanent passthrough bug that was introduced.

A more comprehensive server/stream_processor health state integration will follow in https://github.com/livepeer/pytrickle/compare/main...feat/frameprocessor-server-health