### PR TITLE
gracefully handle connection failed errors during capability registration

### DIFF
--- a/pytrickle/utils/register.py
+++ b/pytrickle/utils/register.py
@@ -81,6 +81,7 @@ class RegisterCapability:
             if attempt < max_retries:
                 await asyncio.sleep(delay)
             else:
+                self.logger.warning("All registration retries failed")
                 return False
                 
         return False


### PR DESCRIPTION
This change catches connection failed errors and logs them to avoid throwing an error when orchestrator registration fails due to connection timeout during startup