### PR TITLE
update to use input frame queue for generative streams

### DIFF
--- a/pytrickle/client.py
+++ b/pytrickle/client.py
@@ -150,15 +150,6 @@ class TrickleClient:
         """Publish data via the protocol's data publisher."""
         self.data_queue.append(data)
 
-    async def send_output(self, output):
-        """Send output to the egress queue."""
-        try:
-            await asyncio.wait_for(self.output_queue.put(output), timeout=.10)
-        except asyncio.TimeoutError:
-            logger.warning("Output queue is full, dropping frame")
-        except Exception as e:
-            logger.error(f"Error sending output: {e}")
-
     def get_statistics(self) -> dict:
         """Get processing statistics."""
         return {

--- a/pytrickle/stream_processor.py
+++ b/pytrickle/stream_processor.py
@@ -100,27 +100,27 @@ class StreamProcessor:
             logger.error(f"Error sending data: {e}")
             return False
 
-    async def send_frame(self, frame: Union[VideoFrame, AudioFrame]):
-        """Send a video or audio frame to the server."""
+    async def send_input_frame(self, frame: Union[VideoFrame, AudioFrame]):
+        """Send a video or audio frame to the input processing pipeline."""
         if self.server.current_client is None:
-            logger.debug("No active client connection, cannot send frame")
+            logger.debug("No active client connection, cannot send input frame")
             return False
 
         client = self.server.current_client
         # Check if client is in error state or stopping
         if client.error_event.is_set() or client.stop_event.is_set():
-            logger.debug("Client is in error/stop state, not sending frame")
+            logger.debug("Client is in error/stop state, not sending input frame")
             return False
 
         try:
-            logger.debug("sending frame to client")
+            logger.debug("sending input frame to client")
             if isinstance(frame, VideoFrame):
-                await client.send_output(VideoOutput(frame, self.server.current_client.request_id))
+                await client.video_input_queue.put(frame)
             elif isinstance(frame, AudioFrame):
-                await client.send_output(AudioOutput(frame, self.server.current_client.request_id))
+                await client.audio_input_queue.put(frame)
             return True
         except Exception as e:
-            logger.error(f"Error sending frame: {e}")
+            logger.error(f"Error sending input frame: {e}")
             return False
 
     async def run_forever(self):


### PR DESCRIPTION
This updates sending frames for generative pipelines to use the input queue. 

This fixes the output being delayed by 5 segments which I was never able to solve.