### PR TITLE
replace pynvml with nvidia-ml-py in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,4 +16,4 @@ pytest-mock>=3.10.0
 
 # Optional performance enhancements
 uvloop>=0.17.0; sys_platform != "win32"
-pynvml
+nvidia-ml-py


### PR DESCRIPTION
Resolves a deprecation warning by replacing `pynvml` with `nvidia-ml-py`

```
FutureWarning: The pynvml package is deprecated. Please install nvidia-ml-py instead. If you did not install pynvml directly, please report this to the maintainers of the package that installed pynvml for you.
```