### PR TITLE
fix generative stream HxW

### DIFF
--- a/pytrickle/encoder.py
+++ b/pytrickle/encoder.py
@@ -99,6 +99,7 @@ def encode_av(
         # Add a new stream to the output using the desired video codec
         target_width = video_meta.get('target_width', DEFAULT_WIDTH)
         target_height = video_meta.get('target_height', DEFAULT_HEIGHT)
+        logger.info(f"Encoding video to {target_width}x{target_height} using codec {video_codec}")
         video_opts = {'video_size': f'{target_width}x{target_height}', 'bf': '0'}
         if video_codec == 'libx264':
             video_opts = video_opts | {'preset': 'superfast', 'tune': 'zerolatency', 'forced-idr': '1'}
@@ -303,7 +304,7 @@ def _log_frame_timestamps(frame_type: str, frame: InputFrame):
     log_duration('post_process_frame', 'frame_end')
     log_duration('frame_init', 'frame_end') 
 
-def default_output_metadata(height: int, width: int):
+def default_output_metadata(width: int, height: int):
     """Generate default metadata for output streams."""
     return {
         'video': {


### PR DESCRIPTION
Fix bug in default video metadata the reversed width and height.

Output metadata is set here for generative streams: https://github.com/livepeer/pytrickle/blob/65256fd4727c5907afcb28e7215ffaded257cf3f/pytrickle/protocol.py#L164

Also added a log line to print the output stream resolution and codec to help confirm output.