### PR TITLE
feat(frame_processor): add optional `on_stream_start` method callback

### DIFF
--- a/examples/process_video_example.py
+++ b/examples/process_video_example.py
@@ -80,6 +80,15 @@ async def send_periodic_status():
     except Exception as e:
         logger.error(f"Error in background status task: {e}")
 
+async def on_stream_start():
+    """Called when stream starts - initialize resources."""
+    global background_task_started
+    logger.info("Stream started, initializing resources")
+    
+    # Reset background task flag for new stream
+    background_task_started = False
+    logger.info("Stream initialization complete")
+
 async def on_stream_stop():
     """Called when stream stops - cleanup background tasks."""
     global background_tasks, background_task_started
@@ -206,6 +215,7 @@ if __name__ == "__main__":
         video_processor=process_video,
         model_loader=load_model,
         param_updater=update_params,
+        on_stream_start=on_stream_start,
         on_stream_stop=on_stream_stop,
         name="green-processor",
         port=8000,

--- a/pytrickle/client.py
+++ b/pytrickle/client.py
@@ -87,6 +87,14 @@ class TrickleClient:
         # Start the protocol
         await self.protocol.start()
         
+        # Call the optional on_stream_start callback after protocol starts
+        if self.frame_processor.on_stream_start:
+            try:
+                await self.frame_processor.on_stream_start()
+                logger.info("Stream start callback executed successfully")
+            except Exception as e:
+                logger.error(f"Error in stream start callback: {e}")
+        
         # Start processing loops
         self.running = True
         

--- a/pytrickle/frame_processor.py
+++ b/pytrickle/frame_processor.py
@@ -109,6 +109,18 @@ class FrameProcessor(ABC):
         """
         pass
 
+    async def on_stream_start(self):
+        """
+        Called when a stream starts or client connects.
+        
+        Override this method to perform initialization operations like:
+        - Starting background tasks
+        - Initializing state
+        - Setting up resources
+        - Starting timers or loops
+        """
+        pass
+
     async def on_stream_stop(self):
         """
         Called when a stream stops or client disconnects.


### PR DESCRIPTION
This change adds an optional `on_stream_start` callback for frame processors. The callback is triggered by trickle client when a new stream starts similar to `on_stream_stop` when a stream stops