### PR TITLE
fix: ensure segments cut if packets received on one stream

### DIFF
--- a/pytrickle/encoder.py
+++ b/pytrickle/encoder.py
@@ -89,7 +89,7 @@ def encode_av(
         return write_file
     
     # keep the internal buffer around segment time, this will let ffmpeg flush packets to segment io even if one stream does not have packets
-    options = {'max_interleave_delta': GOP_SECS * 1050000}  
+    options = {'max_interleave_delta': str(GOP_SECS * 1050000)}  
     # Open the output container in write mode
     output_container = av.open("%d.ts", format='segment', mode='w', io_open=custom_io_open, options=options)
 


### PR DESCRIPTION
Add option to ffmpeg container to make sure the segment format will write segments even if packets for one of the streams is not there.

The trickle segments capture when pyav writes the segment data to the custom_io_open write_file and send the data in the trickle segment.  If pyav does not write segments then the first trickle segment will hang.

The default buffer ffmpeg waits is 10 seconds: https://ffmpeg.org/ffmpeg-formats.html#Options-32 (see `max_interleave_delta` option).  

Another solution could be to require output stream information on startup of a generative stream (`{"output_audio": false, "output_video": true}` and pass correct metadata to the encoder to setup video/audio streams if applicable.