### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,6 @@
 name: Run Python Tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/livepeer/pytrickle/security/code-scanning/1](https://github.com/livepeer/pytrickle/security/code-scanning/1)

To fix the problem, add a `permissions` block at the root of the workflow (preferred for simple workflows like this). This block should restrict the GITHUB_TOKEN to only the minimal required access, which is `contents: read` for checking out code and running tests.  
- Insert the following lines after the `name: Run Python Tests` entry and before `on:` in `.github/workflows/test.yml`:
  ```yaml
  permissions:
    contents: read
  ```
- No additional code, imports, or changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
