### PR TITLE
fix(state, server): consolidate duplicate status fields and fix server state response

### DIFF
--- a/pytrickle/server.py
+++ b/pytrickle/server.py
@@ -832,7 +832,7 @@ class StreamServer:
     def get_health_summary(self) -> str:
         """Get a simple health status string."""
         state = self.state.get_pipeline_state()
-        return state.get('state', 'unknown')
+        return state.get('status', 'unknown')
 
     async def run_forever(self):
         """Run the server forever."""

--- a/pytrickle/state.py
+++ b/pytrickle/state.py
@@ -215,12 +215,8 @@ class StreamState:
             status = "LOADING"
             
         return {
-            "status": status,  # Primary health status
-            "state": status,   # Backward compatibility 
-            "error_message": None,  # Keep compatibility with previous health payload
+            "status": status,
             "pipeline_ready": self.pipeline_ready,
             "active_streams": self.active_streams,
             "startup_complete": self.startup_complete,
-            "pipeline_state": self._state.name,  # Internal state name for debugging
-            "additional_info": {},
         }

--- a/pytrickle/state.py
+++ b/pytrickle/state.py
@@ -70,12 +70,11 @@ class StreamState:
         """Compatibility: True when the pipeline is warmed/ready."""
         return self._state in (PipelineState.IDLE, PipelineState.OK)
 
-    def _update_state_from_activity(self) -> None:
-        """Update internal state based on current activity levels.
+    def set_active_client(self, active: bool):
+        """Track whether there's an active streaming client."""
+        self.active_client = active
         
-        Transitions between OK and IDLE states based on whether there are
-        active streams or clients. Only transitions if not in ERROR state.
-        """
+        # Transition internal state based on activity (only if not in ERROR state)
         if not self.error_event.is_set():
             if self.active_streams > 0 or self.active_client:
                 if self._state != PipelineState.OK:
@@ -83,11 +82,6 @@ class StreamState:
             elif self.startup_complete and self.pipeline_ready:
                 if self._state != PipelineState.IDLE:
                     self.set_state(PipelineState.IDLE)
-
-    def set_active_client(self, active: bool):
-        """Track whether there's an active streaming client."""
-        self.active_client = active
-        self._update_state_from_activity()
 
     def update_component_health(self, component_name: str, health_data: dict):
         """Update component health and log errors without persisting them.
@@ -169,7 +163,15 @@ class StreamState:
     def update_active_streams(self, count: int) -> None:
         """Update number of active streams for health/status reporting."""
         self.active_streams = max(0, int(count))
-        self._update_state_from_activity()
+        
+        # Transition internal state based on activity (only if not in ERROR state)
+        if not self.error_event.is_set():
+            if self.active_streams > 0 or self.active_client:
+                if self._state != PipelineState.OK:
+                    self.set_state(PipelineState.OK)
+            elif self.startup_complete and self.pipeline_ready:
+                if self._state != PipelineState.IDLE:
+                    self.set_state(PipelineState.IDLE)
 
     def is_error(self) -> bool:
         return self.error_event.is_set()

--- a/tests/test_state_integration.py
+++ b/tests/test_state_integration.py
@@ -66,7 +66,7 @@ class TestStreamStateCore:
         state.update_active_streams(1)
         state.set_active_client(True)
         data = state.get_state()
-        assert state.state == PipelineState.IDLE  # Internal state doesn't auto-transition
+        assert state.state == PipelineState.OK  # Internal state auto-transitions to OK after stream starts
         assert data["status"] == "OK"  # But status reflects activity
         
         # When streams stop → status becomes IDLE


### PR DESCRIPTION
This pull request improves the accuracy and responsiveness of the server's internal state transitions and health reporting. The main focus is on ensuring the pipeline state automatically updates based on client and stream activity, and on cleaning up the health status payload for clarity and consistency.

**State transition improvements:**

* The internal pipeline state now automatically transitions to `OK` when there are active streams or an active client, and to `IDLE` when there is no activity, provided the system is not in an error state. This logic is applied in both the `set_active_client` and `update_active_streams` methods for consistency. [[1]](diffhunk://#diff-25ce034b95b65aa44adb4d51f7bf199e756073732bf87036687b969db9ca9058R77-R85) [[2]](diffhunk://#diff-25ce034b95b65aa44adb4d51f7bf199e756073732bf87036687b969db9ca9058R167-R175)

* The test for state transitions in `test_state_integration.py` is updated to expect the state to auto-transition to `OK` when a stream starts, reflecting the new behavior.

**Health status reporting changes:**

* The health summary in `server.py` now consistently reports the `status` field instead of the legacy `state` field.

* The `get_pipeline_state` method's returned dictionary is simplified: it now omits the redundant `state`, `pipeline_state`, and `additional_info` fields, and only includes the `status` and other essential pipeline indicators.


Before:
GET `/stream/status`
```
{
    "status": "IDLE",
    "state": "IDLE",
    "error_message": null,
    "pipeline_ready": true,
    "active_streams": 0,
    "startup_complete": true,
    "pipeline_state": "IDLE",
    "additional_info": {},
    "client_active": false
}
```

After:
GET `/stream/status`
```
{
    "status": "IDLE",
    "pipeline_ready": true,
    "active_streams": 0,
    "startup_complete": true,
    "client_active": false
}
```

While streaming:
```
{
    "status": "OK",
    "pipeline_ready": true,
    "active_streams": 1,
    "startup_complete": true,
    "client_active": true,
    "client_running": true,
    "fps": {
        "ingress_video_fps": 15.019144316458277,
        "ingress_audio_fps": 49.99638566362287,
        "egress_video_fps": 15.018221790956062,
        "egress_audio_fps": 49.9960214019784
    },
    "current_params": {
        "subscribe_url": "https://10.10.7.61:9995/ai/trickle/stream-vovnap-a426ba36",
        "publish_url": "https://10.10.7.61:9995/ai/trickle/stream-vovnap-a426ba36-out",
        "gateway_request_id": "stream-vovnap-a426ba36"
    }
}
```