### PR TITLE
fix(protocol, media): notify protocol of publisher errors to ensure stream ends at end of session

### DIFF
--- a/pytrickle/media.py
+++ b/pytrickle/media.py
@@ -35,6 +35,7 @@ async def run_subscribe(
     target_height: Optional[int] = DEFAULT_HEIGHT,
     max_framerate: Union[int, Callable[[], int], None] = DEFAULT_MAX_FRAMERATE,
     subscriber_timeout: Optional[float] = None,
+    error_callback: Optional[Callable] = None,
 ):
     """
     Run subscription loop to receive and decode video streams.
@@ -48,6 +49,7 @@ async def run_subscribe(
         target_height: Target height for decoded frames
         max_framerate: Maximum framerate or callable returning framerate for decoded frames
         subscriber_timeout: Optional timeout for subscriber connection
+        error_callback: Optional callback for error handling
     """
     # Ensure default values are applied if None
     if target_width is None:
@@ -64,7 +66,7 @@ async def run_subscribe(
             _decode_in(in_pipe, frame_callback, put_metadata, write_fd, target_width, target_height, max_framerate)
         )
         subscribe_task = asyncio.create_task(
-            _subscribe(subscribe_url, write_fd, monitoring_callback, subscriber_timeout)
+            _subscribe(subscribe_url, write_fd, monitoring_callback, subscriber_timeout, error_callback)
         )
         await asyncio.gather(subscribe_task, parse_task)
         logger.info("run_subscribe complete")
@@ -79,14 +81,15 @@ async def _subscribe(
     out_pipe,
     monitoring_callback: Optional[Callable] = None,
     subscriber_timeout: Optional[float] = None,
+    error_callback: Optional[Callable] = None,
 ):
     """Subscribe to trickle stream and write data to pipe."""
     first_segment = True
 
     if subscriber_timeout is not None:
-        subscriber_ctx = TrickleSubscriber(url=subscribe_url, connect_timeout_seconds=subscriber_timeout)
+        subscriber_ctx = TrickleSubscriber(url=subscribe_url, connect_timeout_seconds=subscriber_timeout, error_callback=error_callback)
     else:
-        subscriber_ctx = TrickleSubscriber(url=subscribe_url)
+        subscriber_ctx = TrickleSubscriber(url=subscribe_url, error_callback=error_callback)
     async with subscriber_ctx as subscriber:
         logger.info(f"Launching subscribe loop for {subscribe_url}")
         while True:
@@ -191,6 +194,7 @@ async def run_publish(
     monitoring_callback: Optional[Callable] = None,
     publisher_timeout: Optional[float] = None,
     detect_out_resolution: bool = True,
+    error_callback: Optional[Callable] = None,
 ):
     """
     Run publishing loop to encode and publish video streams.
@@ -204,12 +208,13 @@ async def run_publish(
         detect_out_resolution: If True, detect output resolution from first frame's tensor shape.
                                         If False, use target_width/target_height from decoder metadata.
                                         Default is True to support Super Resolution workflows.
+        error_callback: Optional callback for error handling
     """
     first_segment = True
     publisher = None
     
     try:
-        publisher = TricklePublisher(url=publish_url, mime_type="video/mp2t")
+        publisher = TricklePublisher(url=publish_url, mime_type="video/mp2t", error_callback=error_callback)
         if publisher_timeout is not None:
             publisher.connect_timeout_seconds = publisher_timeout
 

--- a/pytrickle/protocol.py
+++ b/pytrickle/protocol.py
@@ -158,6 +158,7 @@ class TrickleProtocol(TrickleComponent):
                     self.height or DEFAULT_HEIGHT,
                     lambda: self.max_framerate or DEFAULT_MAX_FRAMERATE,
                     self.subscriber_timeout,
+                    self._notify_error,
                 )
             )
         else:
@@ -176,6 +177,7 @@ class TrickleProtocol(TrickleComponent):
                     self.emit_monitoring_event,
                     self.publisher_timeout,
                     self.detect_out_resolution,
+                    self._notify_error,
                 )
             )
         
@@ -328,7 +330,7 @@ class TrickleProtocol(TrickleComponent):
             except queue.Empty:
                 return None
 
-        while not done.is_set() and not self.shutdown_event.is_set():
+        while not done.is_set() and not self.shutdown_event.is_set() and not self.error_event.is_set():
             frame = await asyncio.to_thread(dequeue_frame)
             if frame is None:
                 continue


### PR DESCRIPTION
This change ensures the protocol is notified of publisher errors so the client will cleanup all channels for stream when when the gateway stops streaming without sending a specific stop request.

`TrickleSubscriber` and `TricklePublisher` already accept these error callback methods and are normally used to report = errors to the `TrickleClient`

**Specific Changes**
* Added an optional `error_callback` parameter to the `run_subscribe` and `run_publish` functions in `pytrickle/media.py`, enabling custom error handling during media streaming. [[1]](diffhunk://#diff-6984bd5284b7af72cabb15a5ae95ea10d4f0f732d6b4478393da121aa36a90e7R38) [[2]](diffhunk://#diff-6984bd5284b7af72cabb15a5ae95ea10d4f0f732d6b4478393da121aa36a90e7R197)
* Passed the `error_callback` through to the `TrickleSubscriber` and `TricklePublisher` classes, ensuring error notifications propagate correctly in both subscription and publishing contexts. [[1]](diffhunk://#diff-6984bd5284b7af72cabb15a5ae95ea10d4f0f732d6b4478393da121aa36a90e7R84-R92) [[2]](diffhunk://#diff-6984bd5284b7af72cabb15a5ae95ea10d4f0f732d6b4478393da121aa36a90e7L67-R69) [[3]](diffhunk://#diff-6984bd5284b7af72cabb15a5ae95ea10d4f0f732d6b4478393da121aa36a90e7R211-R217)

* Updated the `start` method in `pytrickle/protocol.py` to forward the error callback to both subscriber and publisher routines, ensuring consistent error handling across protocol operations. [[1]](diffhunk://#diff-f1e4535db260fa1af520b44c4057fe2b0626101b233037ca0a532471659d7a9dR161) [[2]](diffhunk://#diff-f1e4535db260fa1af520b44c4057fe2b0626101b233037ca0a532471659d7a9dR180)
* Modified the frame dequeue loop in `pytrickle/protocol.py` to stop processing if an error event is set, preventing unnecessary work and potential resource leaks when errors occur.




Improved logs showing stream cleanup (protocol):

```
INFO:pytrickle.subscriber:Trickle sub preconnecting attempt: 0 URL: https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca/97
INFO:pytrickle.publisher:Setting up next connection for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-out/96
INFO:pytrickle.publisher:Preconnecting to URL: https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-out/97
INFO:pytrickle.publisher:Setting up next connection for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/22
INFO:pytrickle.publisher:Preconnecting to URL: https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/23
INFO:__main__:Sent status update #40
INFO:__main__:Sent status update #41
INFO:pytrickle.publisher:Setting up next connection for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/23
INFO:pytrickle.publisher:Preconnecting to URL: https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/24
INFO:__main__:Sent status update #42
INFO:__main__:Sent status update #43
INFO:pytrickle.publisher:Setting up next connection for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/24
INFO:pytrickle.publisher:Preconnecting to URL: https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/25
INFO:__main__:Sent status update #44
INFO:pytrickle.media:Failed to read segment - 
INFO:pytrickle.subscriber:Closing https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca
INFO:pytrickle.subscriber:Cancelling 1 background preconnect tasks for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca
INFO:pytrickle.subscriber:All background tasks cancelled for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca
INFO:pytrickle.subscriber:Session closed for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca
INFO:__main__:Sent status update #45
ERROR:pytrickle.publisher:Trickle POST exception https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-out/96 - 
ERROR:pytrickle.base:Component publisher error: post_exception: 
ERROR:pytrickle.base:Component protocol error: post_exception: 
INFO:pytrickle.client:Protocol event received: post_exception - 
INFO:pytrickle.client:Processing loop completed, sending sentinel to egress loop
INFO:pytrickle.publisher:Setting up next connection for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/25
INFO:pytrickle.publisher:Preconnecting to URL: https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/26
WARNING:__main__:Failed to send status update #46, stopping
INFO:pytrickle.publisher:Setting up next connection for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/26
INFO:pytrickle.publisher:Preconnecting to URL: https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/27
INFO:pytrickle.publisher:Setting up next connection for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/27
INFO:pytrickle.publisher:Preconnecting to URL: https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/28
INFO:pytrickle.publisher:Setting up next connection for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/28
INFO:pytrickle.publisher:Preconnecting to URL: https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/29
INFO:pytrickle.publisher:Setting up next connection for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/29
INFO:pytrickle.publisher:Preconnecting to URL: https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/30
INFO:pytrickle.publisher:Setting up next connection for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/30
INFO:pytrickle.publisher:Preconnecting to URL: https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/31
INFO:pytrickle.publisher:Setting up next connection for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/31
INFO:pytrickle.publisher:Preconnecting to URL: https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/32
INFO:pytrickle.publisher:Setting up next connection for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/32
INFO:pytrickle.publisher:Preconnecting to URL: https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/33
INFO:pytrickle.publisher:Setting up next connection for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/33
INFO:pytrickle.publisher:Preconnecting to URL: https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/34
INFO:pytrickle.publisher:Setting up next connection for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/34
INFO:pytrickle.publisher:Preconnecting to URL: https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/35
INFO:pytrickle.publisher:Setting up next connection for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/35
INFO:pytrickle.publisher:Preconnecting to URL: https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events/36
INFO:pytrickle.client:Stopping protocol due to client loops ending
INFO:__main__:Stream stopped, cleaning up background tasks
INFO:__main__:All background tasks cleaned up
INFO:pytrickle.stream_processor:StreamProcessor 'green-processor' stream stop callback executed successfully
INFO:pytrickle.client:Stream stop callback executed successfully
INFO:pytrickle.protocol:Stopping trickle protocol
INFO:pytrickle.client:Protocol event received: protocol_shutdown - None
INFO:pytrickle.subscriber:Closing https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-control
INFO:pytrickle.subscriber:No background tasks to cancel for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-control
INFO:pytrickle.subscriber:Session closed for https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-control
INFO:pytrickle.publisher:Closing https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-events
INFO:pytrickle.publisher:Cancelling 1 background preconnect tasks
INFO:pytrickle.publisher:All background tasks cancelled immediately
INFO:pytrickle.publisher:Session closed immediately
INFO:pytrickle.encoder:Stopping encoder
INFO:pytrickle.media:run_publish complete
INFO:pytrickle.publisher:Closing https://10.10.7.61:8933/ai/trickle/56d285e1-cab3-4021-96df-45b14b425eca-out
INFO:pytrickle.publisher:Session closed immediately
INFO:pytrickle.protocol:All protocol tasks completed gracefully
INFO:pytrickle.server:Client stream completed successfully
`1``